### PR TITLE
Checking if current frame is beginning of any trial

### DIFF
--- a/behavior/MouseTracking/get_mouse_XY_pos.m
+++ b/behavior/MouseTracking/get_mouse_XY_pos.m
@@ -147,7 +147,7 @@ function [ centroids ] = get_mouse_XY_pos( movie, varargin )
                 
                 % trial_aware mode
                 % if image is the first image of a trial, use next centroid
-                if trial_aware && find(true_frame_idx==trial_indices(:,1),1)
+                if trial_aware && any(true_frame_idx==trial_indices(:,1))
                     reassign_prev_centroid = 1;
                     lost_centroids = lost_centroids+1;
                     centroid_color = 'm';


### PR DESCRIPTION
@forea This is a simple fix to the bug that stopped my initial run of `get_mouse_XY_pos`. Also, `any` is cleaner logic here than `find(..., 1)`.

More substantial changes to the script to follow later.
