### PR TITLE
Issue warning on match conflict

### DIFF
--- a/ds/@MultiDay/MultiDay.m
+++ b/ds/@MultiDay/MultiDay.m
@@ -55,7 +55,7 @@ classdef MultiDay < handle
             for i = obj.valid_days
                 for j = setdiff(obj.valid_days, i)
                     if isempty(obj.match{i,j})
-                        fprintf('Warning! No match provided from Day %d to Day %d!\n', i, j);
+                        fprintf('  Warning! No match provided from Day %d to Day %d!\n', i, j);
                     end
                 end
             end
@@ -177,6 +177,10 @@ classdef MultiDay < handle
                 [k, cell_idx] = linear_to_day(I);
                 day = obj.valid_days(k);
                 if obj.ds{day}.is_cell(cell_idx) % Keep only classified cells
+                    if (M(assignment, k) ~= 0) % There is an existing assignment!
+                        fprintf('  Warning! Cells %d and %d from Day %d match to the same cross-day set!\n',...
+                            M(assignment, k), cell_idx, obj.valid_days(k));
+                    end
                     M(assignment, k) = cell_idx;
                 end
             end


### PR DESCRIPTION
@inanhkn @forea With this PR, `MultiDay` objects will issue a warning when encountering a cross-day "match conflict" (explained below). I observed this when working with the m1d12 / m1d13 / m1d14 matches (based on "Rec1"):

```
>> ds_list = {12, m1d12; 13, m1d13; 14, m1d14};
>> match_list = {12, 13, m_12to13, m_13to12; 12, 14, m_12to14, m_14to12; 13, 14, m_13to14, m_14to13};
>> m1 = MultiDay(ds_list, match_list);
08-Sep-2015 20:28:31: Day 12 has 208 classified cells (out of 222)
08-Sep-2015 20:28:31: Day 13 has 182 classified cells (out of 188)
08-Sep-2015 20:28:31: Day 14 has 160 classified cells (out of 176)
  Warning! Cells 29 and 165 from Day 12 match to the same cross-day set!
  Warning! Cells 147 and 157 from Day 14 match to the same cross-day set!
08-Sep-2015 20:28:31: Found 125 matching classified cells across all days
```

I'm defining a "match conflict" to be the case when multiple cells from the same day match to the same set of cross-day cells. Such a conflict may occur even when `run_alignment` is run with the `bijective` option (default), and generally occurs with overlapping cells on a given day. For example, Cells 29 and 165 of Day 12 are shown below:
![image](https://cloud.githubusercontent.com/assets/2081503/9752778/224b3214-5669-11e5-9be7-a6abccafdd41.png)

I'll use Cells 29 and 165 from Day 12 for the discussion. In this example:
- Day 12 / Cell 29 matches to: Day 13 / Cell 58 (and no match in Day 14)
- Day 12 / Cell 165 matches to: Day 14 / Cell 139 (and no match in Day 13)
- Day 13 / Cell 58 matches to: Day 12 / Cell 29 (as needed by `bijective` option in `run_alignment) and Day 14 / Cell 139

If you map this relationship as a graph, the connectivity is as follows:
![image](https://cloud.githubusercontent.com/assets/2081503/9752896/847132ee-566a-11e5-8439-e300763f5600.png)

Now, by the definition of "matching" as introduced in #140, this means that both Cells 29 and 165 from Day 12 match to the same set of cross-day cells (i.e. Day 13 / Cell 58 and Day 14 / Cell 139), which is the "match conflict."

With this PR, `MultiDay` will issue a warning when it detects such a match conflict. Behaviorally, it will overwrite with the latest match, following the cell index order. (In this case Day12 / Cell 165 would be chosen.)

In the future, beyond issuing a warning, we might explicitly require the user to explicitly resolve such match conflicts.
