### PR TITLE
MD accessor get_trial

### DIFF
--- a/ds/@MultiDay/MultiDay.m
+++ b/ds/@MultiDay/MultiDay.m
@@ -119,6 +119,14 @@ classdef MultiDay < handle
             indices = obj.matched_indices(:, selected_days);
         end
         
+        function trial = get_trial(obj, day_idx, trial_idx)
+            trial = obj.day(day_idx).trials(trial_idx);
+            
+            % Reorder the traces to match the common (matched) index
+            day_cell_indices = obj.get_indices(day_idx);
+            trial.traces = trial.traces(day_cell_indices, :);
+        end
+        
         % Accessors using "common index" (i.e. indexing variable over the
         % matched cells -- not specific to day)
         %------------------------------------------------------------


### PR DESCRIPTION
@inanhkn Added accessor `get_trial(day_idx, trial_idx)` into `MultiDay`. The top-level `MultiDay` will pull the trial information (from its internal `DaySummary`), but rearrange the traces of that trial so that only the matched cells are included. Example:

```
>> m1 = MultiDay(ds_list, match_list);
09-Sep-2015 13:46:13: Day 12 has 424 classified cells (out of 888)
09-Sep-2015 13:46:13: Day 13 has 453 classified cells (out of 845)
09-Sep-2015 13:46:13: Found 370 matching classified cells across all days

>> trial12_1 = m1.get_trial(12, 1)

trial12_1 = 

      start: 'east'
       goal: 'north'
        end: 'south'
    correct: 0
       turn: 'left'
       time: 15.2610
     traces: [370x147 double]

>> trial13_1 = m1.get_trial(13, 1)

trial13_1 = 

      start: 'east'
       goal: 'north'
        end: 'north'
    correct: 1
       turn: 'right'
       time: 14.2240
     traces: [370x137 double]
```

Note that both `trial.traces` are [370 x trial_length]. The 370 reflects the fact that there are 370 matched cells from the `DaySummary`, and they are ordered so that `trial12_1.traces(1,:)` and `trial13_1.traces(1,:)` are the same matched cell.

Note that this is not the same as accessing `trials` from the internal `DaySummary`:

```
>> m1.day(12).trials(1)

ans = 

      start: 'east'
       goal: 'north'
        end: 'south'
    correct: 0
       turn: 'left'
       time: 15.2610
     traces: [888x147 double]
```

Specifically, accessing `trials` through `DaySummary` will actually return all cells (classified or not) associated with that day.
