### PR TITLE
add support for trial portions in get_trials()

### DIFF
--- a/ds/@MultiDay/MultiDay.m
+++ b/ds/@MultiDay/MultiDay.m
@@ -154,10 +154,6 @@ classdef MultiDay < handle
                                     ds.filter_trials('incorrect');
                             case {'split_trial_phases'}
                                 split_trial_phases = 1;
-                                frame_indices = ds.trial_indices(trial_indices,:);
-                                % Remove offsets
-                                frame_indices = bsxfun(@minus,frame_indices,...
-                                    frame_indices(:,1)-1);
                         end
                     end
                 end
@@ -166,6 +162,10 @@ classdef MultiDay < handle
             trial_indices = intersect(trial_indices,find(filtered_trials));
             trials = ds.trials(trial_indices);  
             if split_trial_phases
+                frame_indices = ds.trial_indices(trial_indices,:);
+                % Remove offsets
+                frame_indices = bsxfun(@minus,frame_indices,...
+                    frame_indices(:,1)-1);
                 frame_indices = frame_indices(trial_indices,:);
             end
             


### PR DESCRIPTION
Added functionality to request specific portions of trials in the `get_trials()` method for `MultiDay`. The supported trial portions are:
`pre` : from trial start till the first gate opens
`run` : from the opening of the first gate till the end gate closes
`post` : after the end gate closes

Call the method with an additional  `trial_portions` input which is a cell array that contains a subset of the above strings.

Here's an example call:

```
ds_list = {1,ds};
md = MultiDay(ds_list,{});

09-Sep-2015 14:56:28: Day 1 has 437 classified cells (out of 437)
09-Sep-2015 14:56:28: Found 437 matching classified cells across all days

md.get_trials(1,1,{'pre','post','run'})

ans = 

      start: 'east'
       goal: 'north'
        end: 'south'
    correct: 0
       turn: 'left'
       time: 15.2610
     traces: {[437x50 single]  [437x50 single]  [437x47 single]}

```

When the method is called with the optional `trial_portions`, the `traces` field in the output becomes a cell array where the elements in the array correspond to the asked portions and are in the order they were requested with the input `trial_portions`. 
