### PR TITLE
Kimth/strict match

### DIFF
--- a/ds/@MultiDay/MultiDay.m
+++ b/ds/@MultiDay/MultiDay.m
@@ -62,6 +62,7 @@ classdef MultiDay < handle
             
             % Compute matches
             M = obj.compute_all_matches();
+            M = obj.verify_match_consistency(M);
             
             % Filter out rows of M with unmatched indices (i.e. zeros) and
             % store result
@@ -249,6 +250,7 @@ classdef MultiDay < handle
             end % di
             
             num_invalid_matches = sum(~is_valid);
+            Mf = M(is_valid, :);
             fprintf('  Removed %d inconsistent matches!\n', num_invalid_matches);
             
         end % verify_match_consistency


### PR DESCRIPTION
@inanhkn Follow up from #142.

The subfunction `verify_match_consistency` requires that all pairs of cell matchings is consistent with the provided `match_list`.

When a complete `match_list` is provided (as in the following example), `verify_match_consistency` ensures that a matched set is a complete graph.

```
>> ds_list

ds_list = 

    [12]    [1x1 DaySummary]
    [13]    [1x1 DaySummary]
    [14]    [1x1 DaySummary]

>> match_list

match_list = 

    [12]    [13]    {222x1 cell}    {188x1 cell}
    [12]    [14]    {222x1 cell}    {176x1 cell}
    [13]    [14]    {188x1 cell}    {176x1 cell}

>> m1 = MultiDay(ds_list, match_list);
10-Sep-2015 16:55:02: Day 12 has 208 classified cells (out of 222)
10-Sep-2015 16:55:02: Day 13 has 182 classified cells (out of 188)
10-Sep-2015 16:55:02: Day 14 has 160 classified cells (out of 176)
  Warning! Cells 29 and 165 from Day 12 match to the same cross-day set!
  Warning! Cells 147 and 157 from Day 14 match to the same cross-day set!
  Removed 2 inconsistent matches!
10-Sep-2015 16:55:02: Found 123 matching classified cells across all days
```
