### PR TITLE
Add at least one entry to /Params -- to make files compatible with fi…

### DIFF
--- a/io/save_movie_to_hdf5.m
+++ b/io/save_movie_to_hdf5.m
@@ -18,3 +18,7 @@ h5create(outname, dataset_name, [height width num_frames],...
     'DataType', data_type,...
     'ChunkSize', chunk_size);
 h5write(outname, dataset_name, movie);
+
+% Create standard "/Params" directory
+h5create(outname, '/Params/NumFrames', 1);
+h5write(outname, '/Params/NumFrames', num_frames);


### PR DESCRIPTION
This minor fix to `save_movie_to_hdf5` makes it so that the resulting movies are directly compatible with existing file-to-file preprocessing methods.
