### PR TITLE
support for cell-with-problems

### DIFF
--- a/classification/classify_cells.m
+++ b/classification/classify_cells.m
@@ -51,7 +51,7 @@ while (cell_idx <= num_candidates)
                     go_to_next_unlabeled_cell();
                 end
 
-            case {'p!', 'c!', 'n'} % Classify without viewing trace
+            case {'p!', 'c!', 'x', 'n'} % Classify without viewing trace
                 set_label(cell_idx, resp(1));
                 go_to_next_unlabeled_cell();
                 
@@ -129,6 +129,8 @@ ds.save_class(output_name);
                 full_label = 'phase-sensitive cell';
             case 'c'
                 full_label = 'cell';
+            case 'x'
+                full_label = 'cell with problems';
             case 'n'
                 full_label = 'not a cell';
         end

--- a/ds/@DaySummary/DaySummary.m
+++ b/ds/@DaySummary/DaySummary.m
@@ -210,21 +210,6 @@ classdef DaySummary < handle
             end
         end
         
-        function is_cell = is_cell(obj, cell_indices)
-            % When 'cell_indices' is omitted, then return the label of all
-            % cells
-            if ~exist('cell_indices', 'var')
-                cell_indices = 1:obj.num_cells;
-            end
-            
-            is_cell = zeros(size(cell_indices));
-            for k = 1:length(cell_indices)
-                cell_idx = cell_indices(k);
-                is_cell(k) = any(strcmp(obj.cells(cell_idx).label,...
-                    {'phase-sensitive cell', 'cell'}));
-            end
-        end
-        
         function is_correct = get_trial_correctness(obj)
             is_correct = cellfun(@strcmp, {obj.trials.goal}, {obj.trials.end});
         end
@@ -258,6 +243,21 @@ classdef DaySummary < handle
         
         % Classification
         %------------------------------------------------------------
+        function is_cell = is_cell(obj, cell_indices)
+            % When 'cell_indices' is omitted, then return the label of all
+            % cells (1=cell, 0=not a cell)
+            if ~exist('cell_indices', 'var')
+                cell_indices = 1:obj.num_cells;
+            end
+            
+            is_cell = zeros(size(cell_indices));
+            for k = 1:length(cell_indices)
+                cell_idx = cell_indices(k);
+                is_cell(k) = any(strcmp(obj.cells(cell_idx).label,...
+                    {'phase-sensitive cell', 'cell'}));
+            end
+        end
+        
         function class = get_class(obj)
             class = {obj.cells.label}'; % Column cell
         end

--- a/ds/@DaySummary/plot_cell_map.m
+++ b/ds/@DaySummary/plot_cell_map.m
@@ -29,14 +29,20 @@ function plot_cell_map(obj, color_grouping, varargin)
     % By default, color the cells based on classification
     if ~exist('color_grouping', 'var') || enable_class_colors
         for k = 1:obj.num_cells
-            % Note: Unlabeled cells remain white!
-            if isempty(obj.cells(k).label)
-                cell_colors{k} = 'w';
+            if obj.is_cell(k)
+                cell_colors{k} = 'g';
             else
-                if obj.is_cell(k)
-                    cell_colors{k} = 'g';
-                else
-                    cell_colors{k} = 'r';
+                cell_label = obj.cells(k).label;
+                if isempty(cell_label)
+                    cell_colors{k} = 'w'; % Unlabeled cells are white
+                else % More nuanced coloring
+                    switch cell_label    
+                        case 'cell with problems'
+                            cell_colors{k} = 'y';
+
+                        otherwise % All other labels considered to be not a cell
+                            cell_colors{k} = 'r';
+                    end
                 end
             end
         end


### PR DESCRIPTION
@inanhkn Support for a new classification option (beyond "phase-sensitive cell", "cell", "not a cell"), called "cell with problems".

The label is indicated via `x` in `classify_cells`:

```
>> classify_cells(m4d26, M);
  15-Nov-2015 12:43:12: Movie will be displayed with fixed CLim = [-0.049 0.080]...
Classifier (1/808, "") >> x
  Candidate 1 classified as cell with problems
```

These cells are marked with a yellow boundary in `plot_cell_map`.

This label is intended to handle cases like:
- There is an actual cell at the indicated ROI, but the trace is significantly contaminated by nearby sources, i.e. multiple cells in the source.
- There is an actual cell at the indicated ROI, but the filter shape is (significantly) nonrepresentative of the cell, i.e. unconverged spatial filter.

By indicating cases like these with its own label, we can return to these sources later (e.g. for extraction algorithm improvement), and also get a better sense of the number of cells present in the movie.

Note that "cell with problems" will not be considered a valid cell for subsequent analysis. The method `DaySummary.is_cell` only considers "phase-sensitive cell" and "cell" to be valid cells.
