### PR TITLE
Load from tif using appropriate data type

### DIFF
--- a/io/load_movie_from_tif.m
+++ b/io/load_movie_from_tif.m
@@ -7,7 +7,17 @@ num_frames = length(info);
 width  = info(1).Width;
 height = info(1).Height;
 
-movie = zeros(height, width, num_frames, 'single');
+tif_type = info(1).SampleFormat;
+switch tif_type
+    case 'Unsigned integer'
+        type = 'uint16';
+    case 'IEEE floating point'
+        type = 'single';
+    otherwise
+        error('load_movie_from_tif: Unrecognized type "%s"\n', tif_type);
+end
+
+movie = zeros(height, width, num_frames, type);
 
 % Load into memory
 t = Tiff(source, 'r');

--- a/io/save_movie_to_tif.m
+++ b/io/save_movie_to_tif.m
@@ -22,7 +22,7 @@ switch (lower(type))
         tagstruct.SampleFormat = Tiff.SampleFormat.UInt;
         tagstruct.BitsPerSample = 16;
     otherwise
-        error('save_movie_to_tif.m: Unrecognized type "%s"\n', type);
+        error('save_movie_to_tif: Unrecognized type "%s"\n', type);
 end
 
 t = Tiff(outname, 'w8'); % BigTiff format


### PR DESCRIPTION
TIFF files load with the appropriate data type (`uint16` or `single`). Previously loaded always as `single`.
