### PR TITLE
Fori/tracking update

### DIFF
--- a/behavior/MouseTracking/get_mouse_XY_pos.m
+++ b/behavior/MouseTracking/get_mouse_XY_pos.m
@@ -55,7 +55,7 @@ function [ centroids ] = get_mouse_XY_pos( movie, varargin )
                 case 'threshold'
                     threshold_provided = 1;
                     thresh = varargin{k+1};
-                    fprintf('Threshold for detection provided')
+                    fprintf('Threshold for detection provided.\n')
             end
         end
     end


### PR DESCRIPTION
Added the option to specify threshold for detection (how black is the black mouse). Noticed that with my c11m5 video, default threshold = 20 did not work, but 40 did.
