### PR TITLE
Kimth/ds loader

### DIFF
--- a/ds/@DaySummary/DaySummary.m
+++ b/ds/@DaySummary/DaySummary.m
@@ -3,10 +3,10 @@
 % Inputs:
 %   ds_source: Two possibilities:
 %       1) Plus maze text file
-%       2) Struct containing the following fields:
-%           - s.maze: Path to plus maze text file
-%           - s.behavior: Path to behavioral video (e.g. mp4 or m4v)
-%           - s.tracking: Path to tracking text file (*.xy)
+%       2) Struct 's' containing the following fields:
+%           - s.maze: Path to plus maze text file (required)
+%           - s.behavior: Path to behavioral video (optional; e.g. mp4)
+%           - s.tracking: Path to tracking text file (optional; *.xy)
 %
 %   rec_dir: Directory containing 
 %       - Filters and traces in a "rec_*.mat" file (required)
@@ -187,6 +187,7 @@ classdef DaySummary < handle
             obj.behavior_vid = [];
             obj.is_tracking_loaded = false;
             
+            % Load behavior video and tracking data if available
             if isstruct(ds_source)
                 if isfield(ds_source, 'behavior')
                     obj.load_behavior_movie(ds_source.behavior);


### PR DESCRIPTION
@forea cc @inanhkn 

Alternate initialization methods for `DaySummary`.

It can be cumbersome to individually load the behavior video and tracking data into a `DaySummary` instance. This PR introduces an alternative initialization scheme for `DaySummary` -- by providing the "sources struct" -- which will auto-load the behavior video and tracking data:

```
>> sources = data_sources
sources = 
         maze: '_data/c11m1d12_ti2.txt'
     behavior: '_data/c11m1d12_ti2.mp4'
     tracking: '_data/c11m1d12_ti2.xy'
    miniscope: '_data/c11m1d12_gfix_rm_mc_cr_norm40_dff_ti2.hdf5'

>> m1d12 = DaySummary(sources, 'cm01', 'excludeprobe');
18-Feb-2016 16:10:05: Loaded trial metadata from _data/c11m1d12_ti2.txt
18-Feb-2016 16:10:12: Loaded 1223 filters and traces (cellmax) from cm01\rec_151125-102235.mat
  Computing auxiliary spatial parameters... Done (35.9 sec)
  Computing distances between all sources... Done (2.3 sec)
18-Feb-2016 16:11:06: Loaded classification from cm01\class_151125-172203.txt
18-Feb-2016 16:11:09: Loaded behavior video from "_data/c11m1d12_ti2.mp4"
18-Feb-2016 16:11:09: Loaded tracking data from "_data/c11m1d12_ti2.xy"
```

Note that the "old"-stype of providing only the plusmaze text file will continue to work:

```
>> m1d12 = DaySummary(sources.maze, 'cm01', 'excludeprobe');
18-Feb-2016 16:08:43: Loaded trial metadata from _data/c11m1d12_ti2.txt
18-Feb-2016 16:08:52: Loaded 1223 filters and traces (cellmax) from cm01\rec_151125-102235.mat
  Computing auxiliary spatial parameters... Done (36.9 sec)
  Computing distances between all sources... Done (2.3 sec)
18-Feb-2016 16:09:47: Loaded classification from cm01\class_151125-172203.txt
```
