### PR TITLE
Factor out raster alignment code

### DIFF
--- a/view/view_detailed_trial.m
+++ b/view/view_detailed_trial.m
@@ -94,9 +94,12 @@ end
         %------------------------------------------------------------
         trial_frames = double(ds.trial_indices(trial_idx, :)); % [start open-gate close-gate end]
         trial_frames = trial_frames - trial_frames(1) + 1;
-        close_gate_frame = trial_frames(3);
         
-        trial_frames = trial_frames - close_gate_frame; % Time relative to gate close
+        align_index = 3; % Align to closing of gate
+        align_str = 'Frames relative to gate close';
+        alignment_frame = trial_frames(align_index);
+        
+        trial_frames = trial_frames - alignment_frame; % Time relative to gate close
         
         subplot(3,4,[3 4]);
         plot(trial_frames(1):trial_frames(4), trace, 'LineWidth', 2, 'HitTest', 'off');
@@ -104,7 +107,7 @@ end
         ylim(scale);
         grid on;
         title(sprintf('Trial %d', trial_idx));
-        xlabel('Frames relative to gate close');
+        xlabel(align_str);
         ylabel('Signal [a.u.]');
         hold on;
         
@@ -156,15 +159,15 @@ end
         
         function update_frame(~, ~)
             cp = get(trace_axis, 'CurrentPoint');
-            sel_frame = round(cp(1)); % X point of click (i.e. frame relative to gate close)
+            sel_frame = round(cp(1)); % X point of click
             
-            sel_frame = sel_frame + close_gate_frame;
+            sel_frame = sel_frame + alignment_frame;
             sel_frame = max(sel_frame, 1);
             sel_frame = min(sel_frame, num_frames_in_trial);
             
             % Update visuals
-            set(t, 'XData', (sel_frame-close_gate_frame)*[1 1]);
-            set(d, 'XData', (sel_frame-close_gate_frame), 'YData', trace(sel_frame));
+            set(t, 'XData', (sel_frame-alignment_frame)*[1 1]);
+            set(d, 'XData', (sel_frame-alignment_frame), 'YData', trace(sel_frame));
             set(hb, 'CData', Mb(:,:,sel_frame));
             
             subplot(3,4,[7 8 11 12]);


### PR DESCRIPTION
@forea Following on #223. This is mostly a behind-the-scenes PR that generalizes the code underlying raster alignment, so that one can align the raster to any of: (1) starting of trial, (2) open gate, (3) close gate, (4) end of trial.

Default behavior of `plot_cell_raster` is still to align by the closing frame.

On the other hand, you can play with the raster alignment as follows:
```
cell_idx = 95;
for k = 1:4
    subplot(1,4,k);
    m5d07.plot_cell_raster(cell_idx, 'align', k);
end
suptitle(sprintf('m5d07: Cell %d', cell_idx));
```
which produces:
![m5d07_raster-alignments_cell95](https://cloud.githubusercontent.com/assets/2081503/20685996/a25c4436-b56b-11e6-942d-fc29cbea13a9.png)

Another example:
![m5d07_raster-alignments_cell124](https://cloud.githubusercontent.com/assets/2081503/20686005/a9f7a4a6-b56b-11e6-83dd-e3d5e46c26a5.png)
