### PR TITLE
Browse multiday shows traces as signal

### DIFF
--- a/view/browse_multiday.m
+++ b/view/browse_multiday.m
@@ -88,13 +88,14 @@ while (1)
 end
 
     function draw_cell(common_cell_idx)
+        traces = cell(1, md.num_days);
         for k = 1:md.num_days
             day = md.valid_days(k);
             cell_idx_k = md.get_cell_idx(common_cell_idx, day);
             ds = md.day(day); % Just a shorthand
             
             % Draw image of cell on each day
-            subplot(3, md.num_days, k);
+            subplot(4, md.num_days, k);
             cell_image_k = ds.cells(cell_idx_k).im;
             cell_com_k = ds.cells(cell_idx_k).com;
             zoom_half_width = min(size(cell_image_k))/10;
@@ -110,18 +111,39 @@ end
             else
                 title(title_str, 'FontWeight', 'normal');
             end
-%             hold on;
-%             for m = 1:ds.num_cells
-%                 if ds.is_cell(m)
-%                     boundary = ds.cells(m).boundary;
-%                     plot(boundary(:,1), boundary(:,2), 'w');
-%                 end
-%             end
-            
+
             % Draw raster
-            subplot(3, md.num_days, [md.num_days+k 2*md.num_days+k]);
+            subplot(4, md.num_days, [md.num_days+k 2*md.num_days+k]);
             ds.plot_cell_raster(cell_idx_k, 'draw_correct');
+            
+            % Get trace
+            traces{k} = ds.get_trace(cell_idx_k);
         end
+        
+        % Draw traces on a single plot
+        trace_offsets = zeros(1+md.num_days, 1);
+        for k = 1:md.num_days
+            trace_offsets(k+1) = length(traces{k});
+        end
+        trace_offsets = cumsum(trace_offsets);
+        
+        colors = 'rbk';
+        subplot(4, md.num_days, (3*md.num_days+1):(4*md.num_days));
+        for k = 1:md.num_days
+            color = colors(1+mod(k,length(colors)));
+            plot(trace_offsets(k):(trace_offsets(k+1)-1),...
+                 traces{k}, color);
+            hold on;
+        end
+        hold off;
+        grid on;
+        xlim([0 trace_offsets(end)-1]);
+        set(gca, 'XTick', []);
+        full_trace = cell2mat(traces);
+        M = max(full_trace);
+        m = min(full_trace);
+        ylim([m M] + 0.1*(M-m)*[-1 1]);
+        ylabel('Trace [a.u.]');
     end % draw_cell
 
 end % browse_multiday


### PR DESCRIPTION
@forea This PR is a minor modification to `browse_multiday` that shows the calcium trace in absolute units (including any baseline) for all days. The trace is shown in the bottom row of the GUI and is color coded by day. For example:
![browse_multiday_m1d12c246](https://cloud.githubusercontent.com/assets/2081503/20691290/d2b3c2f8-b584-11e6-8f60-eb9718a65fe0.png)

The motivation for this visualization was to confirm that the traces for a single cell have "similar statistics" across days, e.g. scalar amplitude, baseline differences, etc. The concern is that such numerical differences (which can easily arise as artifacts from experimental variations from day-to-day) can result in day-to-day variance that could interfere with methods such as decoding or factor decomposition.

@ahwillia Here are some example traces (I didn't exhaustively search) for the `MultiDay` corresponding to m1d12–m1d14 (i.e. the "Rec" files that you already have):
![browse_multiday_m1d12c116](https://cloud.githubusercontent.com/assets/2081503/20691413/adec1faa-b585-11e6-9dab-9af8259deb70.png)
![browse_multiday_m1d12c129](https://cloud.githubusercontent.com/assets/2081503/20691418/b3610d88-b585-11e6-80fb-e3a371f80340.png)
![browse_multiday_m1d12c175](https://cloud.githubusercontent.com/assets/2081503/20691430/bda75414-b585-11e6-8cca-e206179e657b.png)
![browse_multiday_m1d12c223](https://cloud.githubusercontent.com/assets/2081503/20691436/c0d26052-b585-11e6-9d1a-d0392a3c75db.png)
![browse_multiday_m1d12c237](https://cloud.githubusercontent.com/assets/2081503/20691438/c342063a-b585-11e6-813f-4c165ec4b743.png)

I am going to explore my "baseline corrected" version of the Rec files, and will report back in this PR.