### PR TITLE
Kimth/ds additions

### DIFF
--- a/ds/@DaySummary/DaySummary.m
+++ b/ds/@DaySummary/DaySummary.m
@@ -261,7 +261,8 @@ classdef DaySummary < handle
             end
             filtered_trials = filtered_trials';
 
-            % helper function to filter cell arrays of strings
+            % helper function to filter cell arrays of strings, i.e. enable
+            % selectors such as: filter_trials('start', {'east', 'west'})
             function mask = trial_filter(~, trial_data, selection)
                 if ischar(selection)
                     mask = strcmp(trial_data,selection);
@@ -283,10 +284,16 @@ classdef DaySummary < handle
             count = sum(obj.is_cell);
         end
         
-        function [trace, frame_indices] = get_trace(obj, cell_idx, selected_trials)
-            if ~exist('selected_trials', 'var')
-                selected_trials = 1:obj.num_trials;
+        function [trace, frame_indices, selected_trials] = get_trace(obj, cell_idx, varargin)
+            selected_trials = 1:obj.num_trials;
+            for k = 1:length(varargin)
+                vararg = varargin{k};
+                if isnumeric(vararg)
+                    selected_trials = vararg;
+                end
             end
+            filtered_trials = find(obj.filter_trials(varargin{:}));
+            selected_trials = intersect(selected_trials, filtered_trials)';
             
             trace = [];
             frame_indices = [];


### PR DESCRIPTION
@forea cc @ahwillia This PR adds new ways of accessing neuron traces from a `DaySummary` via `get_trace`. Here are the use cases:

First, the most basic:
```
cell_idx = 23;
tr = m1d13.get_trace(cell_idx);
```
retrieves the trace of Cell 23 for all trials.

Second:
```
cell_idx = 23;
selected_trials = 50:100;
tr = m1d13.get_trace(cell_idx, selected_trials);
```
retrieves the trace of Cell 23 for trials 50 to 100. (Note: the selector `selected_trials` can also be a single trial, or discontiguous set of trials.)

These two access modes of `get_trace` were available previously.

With this PR, I made it so that `get_trace` can also use the `filter_trials` mechanism. So, here are new ways of selecting trials.

Third:
```
cell_idx = 23;
tr = m1d13.get_trace(cell_idx, 'incorrect');
```
retrieves the trace of Cell 23 for trials that the mouse made an incorrect decision.

Fourth:
```
cell_idx = 23;
tr = m1d13.get_trace(cell_idx, 50:100, 'incorrect');
```
retrieves the trace of Cell 23 for trials between 50 to 100, in which the mouse made an incorrect decision. Logically, there are two filters being operated here: first is the 50:100 selector, and the second is the one coming from the `filter_trials` mechanism. The trials that pass both conditions are the ones retrieved by `get_trace`.

There is also an optional output that indicates the trial indices that pass the selection criteria:
```
>> [tr, ~, trial_inds] = m1d13.get_trace(23, 50:100, 'incorrect');
>> trial_inds

trial_inds =
  Columns 1 through 13
    56    58    60    62    63    66    69    71    72    74    75    78    80
  Columns 14 through 20
    82    84    86    89    91    92    97
```

* * * 

Also added a minor convenience function `set_unlabeled_cells` which will set all unlabeled cells in a `DaySummary` instance to `"not a cell"`.