### PR TITLE
Visualize_tca_factors

### DIFF
--- a/tensor/visualize_tca_factors.m
+++ b/tensor/visualize_tca_factors.m
@@ -1,0 +1,194 @@
+function visualize_tca_factors(tca, info, trial_meta)
+% Todo:
+% - Automatic identification of behavioral metadata that best separates
+%   trial vector weights for a given TCA factor.
+
+R = length(tca.lambda); % Rank of the TCA factorization
+[neuron_vs, cluster_boundaries] = soft_cluster_neurons(tca.U{1});
+time_vs = tca.U{2};
+trial_vs = tca.U{3};
+
+num_neurons = size(neuron_vs,1);
+num_trials = size(trial_vs, 1);
+
+neuron_yrange = [0 max(neuron_vs(:))];
+time_yrange = [0 max(time_vs(:))];
+trial_yrange = [0 max(trial_vs(:))];
+
+% Within-trial "time" (as opposed to index). Actual interpretation depends
+% on the info.timewarp_method for trial alignment.
+switch (info.timewarp_method)
+    case 'align_to'
+        t = info.align.axis; % Units of frames
+        t0 = t(t == 0);
+        t = t / 10; % Convert to seconds, assuming FPS = 10
+        % The following assumes info.align.idx == 3, i.e. alignment point
+        % is gate close.
+        time_label = 'Time relative to gate close (s)';
+        
+    otherwise
+        t = 1:size(time_vs,1);
+        time_label = 'Time index';
+end
+
+% Prepare figure for TCA factor visualization
+figure;
+[ha, ~] = tight_subplot(R,3,0.01,0.01,0.01);
+
+% For drawing vertical boundaries between different neuron clusters
+num_dividers = length(cluster_boundaries);
+cluster_boundaries_x = [repmat(cluster_boundaries,1,2) NaN(num_dividers,1)]';
+cluster_boundaries_x = cluster_boundaries_x(:);
+cluster_boundaries_y = [repmat(neuron_yrange,num_dividers,1) NaN(num_dividers,1)]';
+cluster_boundaries_y = cluster_boundaries_y(:);
+
+for r = 1:R
+    neuron_v = neuron_vs(:,r);
+    time_v = time_vs(:,r);
+    trial_v = trial_vs(:,r);    
+
+    % Neuron dimension
+    axes(ha((r-1)*3+1)); %#ok<*LAXES>
+    bar(neuron_v, 'k');
+    ylabel(sprintf('r = %d', r));
+    hold on;
+    plot(cluster_boundaries_x, cluster_boundaries_y, 'k:');
+    hold off;
+    
+    % Time dimension
+    axes(ha((r-1)*3+2));
+    plot(t,time_v,'r');
+    hold on;
+    if (info.timewarp_method == 'align_to')
+        plot(t0*[1 1], time_yrange', 'k:');
+    end
+    hold off;
+
+    % Trial dimension
+    axes(ha((r-1)*3+3));
+    plot(trial_v, '.', 'Color', 0.4*[1 1 1], 'HitTest', 'off');
+    h_factor_trial_axes = gca;
+    h_factor_trial_axes.UserData = struct(...
+        'factor_idx', r,...
+        'trial_coloring', 'none',...
+        'x', (1:num_trials)',...
+        'y', trial_v,...
+        'yrange', trial_yrange);
+    set(h_factor_trial_axes, 'buttonDownFcn',...
+        @(h,e) recolor_trial_vector(h,e,trial_meta));
+end
+
+% Subplot formatting
+%------------------------------------------------------------
+all_subplots = 1:(3*R);
+neuron_col_subplots = 1:3:(3*R);
+time_col_subplots = 2:3:(3*R);
+trial_col_subplots = 3:3:(3*R);
+bottom_row_subplots = all_subplots(end-2:end);
+
+% All plots within a column have the same scale
+set(ha(neuron_col_subplots), 'XLim', [1 num_neurons], 'YLim', neuron_yrange);
+set(ha(time_col_subplots), 'XLim', t([1 end]), 'YLim', time_yrange);
+set(ha(trial_col_subplots), 'XLim', [1 num_trials], 'YLim', trial_yrange);
+
+% Remove ticks and labels except for the bottom row
+set(ha, 'YTickLabel', [], 'YTick', []);
+set(ha(setdiff(all_subplots, bottom_row_subplots)), 'XTickLabel', [], 'XTick', []);
+
+% Other formatting
+set(ha, 'FontName', 'Arial');
+
+% Labels at the very bottom row
+axes(ha(bottom_row_subplots(1)));
+xlabel('Neuron index');
+axes(ha(bottom_row_subplots(2)));
+xlabel(time_label);
+axes(ha(bottom_row_subplots(3)));
+xlabel('Trial index');
+
+tightfig;
+
+end % visualize_tca_factors
+
+function [neuron_vs, cluster_boundaries] = soft_cluster_neurons(neuron_vs)
+    [num_neurons, num_factors] = size(neuron_vs);
+    factor_assignment = zeros(num_neurons, 1);
+    
+    % First, assign neurons to factors based on each neuron's weights to
+    % the TCA factors.
+    for k = 1:num_neurons
+        neuron_factor_weights = neuron_vs(k,:);
+        
+        [~, sorted_inds] = sort(neuron_factor_weights, 'descend');
+        factor_assignment(k) = sorted_inds(1);
+    end
+    [sorted_factor_assignment, sorted_neurons] = ...
+        sort(factor_assignment, 'ascend');
+    
+    % Second, sort within each factor assignment by weight
+    for l = 1:num_factors
+        in_factor_l = (sorted_factor_assignment==l);
+        neurons_in_factor = sorted_neurons(in_factor_l);
+        neuron_factor_weights = neuron_vs(neurons_in_factor,l);
+        [~, sorted_inds] = sort(neuron_factor_weights, 'descend');
+        sorted_neurons(in_factor_l) = neurons_in_factor(sorted_inds);
+    end
+    
+    neuron_vs = neuron_vs(sorted_neurons, :);
+    cluster_boundaries = 1 + find(diff(sorted_factor_assignment));
+end % soft_cluster_neurons
+
+function recolor_trial_vector(h, ~, trial_meta)
+    data = h.UserData;
+    x = data.x;
+    y = data.y;
+    
+    % Cycle through possible new coloring options
+    switch (data.trial_coloring)
+        case 'none'
+            new_coloring = 'start';
+        case 'start'
+            new_coloring = 'end';
+        case 'end'
+            new_coloring = 'correct';
+        case 'correct'
+            new_coloring = 'none';
+        otherwise
+            new_coloring = 'none';
+    end
+    
+    % Apply new metadata coloring
+    set(h, 'NextPlot', 'replacechildren');
+    switch new_coloring
+        case 'none'
+            plot(x, y, '.', 'Color', 0.4*[1 1 1], 'HitTest', 'off');
+        case 'start'
+            east_trials = strcmp(trial_meta.start, 'east');
+            west_trials = strcmp(trial_meta.start, 'west');
+            plot(x(east_trials), y(east_trials), '.', 'Color', 'b', 'HitTest', 'off');
+            hold on;
+            orange = [0.91 0.41 0.17];
+            plot(x(west_trials), y(west_trials), '.', 'Color', orange, 'HitTest', 'off');
+            hold off;
+        case 'end'
+            north_trials = strcmp(trial_meta.end, 'north');
+            south_trials = strcmp(trial_meta.end, 'south');
+            dark_purple = [130 40 137]/255;
+            plot(x(north_trials), y(north_trials), '.', 'Color', dark_purple, 'HitTest', 'off');
+            hold on;
+            plot(x(south_trials), y(south_trials), '.', 'Color', 'm', 'HitTest', 'off');
+            hold off;
+        case 'correct'
+            correct_trials = logical(trial_meta.correct);
+            incorrect_trials = ~correct_trials;
+            dark_green = [0 0.6 0];
+            plot(x(correct_trials), y(correct_trials), '.', 'Color', dark_green, 'HitTest', 'off');
+            hold on;
+            plot(x(incorrect_trials), y(incorrect_trials), '.', 'Color', 'r', 'HitTest', 'off');
+            hold off;
+    end
+    xlim(x([1 end]));
+    ylim(data.yrange);
+    h.UserData.trial_coloring = new_coloring;
+    fprintf('Factor %d now colored by "%s"\n', data.factor_idx, new_coloring);
+end

--- a/utils/tight_subplot.m
+++ b/utils/tight_subplot.m
@@ -1,0 +1,66 @@
+function [ha, pos] = tight_subplot(Nh, Nw, gap, marg_h, marg_w)
+
+% tight_subplot creates "subplot" axes with adjustable gaps and margins
+%
+% [ha, pos] = tight_subplot(Nh, Nw, gap, marg_h, marg_w)
+%
+%   in:  Nh      number of axes in hight (vertical direction)
+%        Nw      number of axes in width (horizontaldirection)
+%        gap     gaps between the axes in normalized units (0...1)
+%                   or [gap_h gap_w] for different gaps in height and width 
+%        marg_h  margins in height in normalized units (0...1)
+%                   or [lower upper] for different lower and upper margins 
+%        marg_w  margins in width in normalized units (0...1)
+%                   or [left right] for different left and right margins 
+%
+%  out:  ha     array of handles of the axes objects
+%                   starting from upper left corner, going row-wise as in
+%                   subplot
+%        pos    positions of the axes objects
+%
+%  Example: ha = tight_subplot(3,2,[.01 .03],[.1 .01],[.01 .01])
+%           for ii = 1:6; axes(ha(ii)); plot(randn(10,ii)); end
+%           set(ha(1:4),'XTickLabel',''); set(ha,'YTickLabel','')
+
+% Pekka Kumpulainen 21.5.2012   @tut.fi
+% Tampere University of Technology / Automation Science and Engineering
+
+
+if nargin<3; gap = .02; end
+if nargin<4 || isempty(marg_h); marg_h = .05; end
+if nargin<5; marg_w = .05; end
+
+if numel(gap)==1; 
+    gap = [gap gap];
+end
+if numel(marg_w)==1; 
+    marg_w = [marg_w marg_w];
+end
+if numel(marg_h)==1; 
+    marg_h = [marg_h marg_h];
+end
+
+axh = (1-sum(marg_h)-(Nh-1)*gap(1))/Nh; 
+axw = (1-sum(marg_w)-(Nw-1)*gap(2))/Nw;
+
+py = 1-marg_h(2)-axh; 
+
+% ha = zeros(Nh*Nw,1);
+ii = 0;
+for ih = 1:Nh
+    px = marg_w(1);
+    
+    for ix = 1:Nw
+        ii = ii+1;
+        ha(ii) = axes('Units','normalized', ...
+            'Position',[px py axw axh], ...
+            'XTickLabel','', ...
+            'YTickLabel','');
+        px = px+axw+gap(2);
+    end
+    py = py-axh-gap(1);
+end
+if nargout > 1
+    pos = get(ha,'Position');
+end
+ha = ha(:);

--- a/utils/tightfig.m
+++ b/utils/tightfig.m
@@ -1,0 +1,233 @@
+function hfig = tightfig(hfig)
+% tightfig: Alters a figure so that it has the minimum size necessary to
+% enclose all axes in the figure without excess space around them.
+% 
+% Note that tightfig will expand the figure to completely encompass all
+% axes if necessary. If any 3D axes are present which have been zoomed,
+% tightfig will produce an error, as these cannot easily be dealt with.
+% 
+% Input
+%
+% hfig - handle to figure, if not supplied, the current figure will be used
+%   instead.
+%
+%
+
+    if nargin == 0
+        hfig = gcf;
+    end
+
+    % There can be an issue with tightfig when the user has been modifying
+    % the contnts manually, the code below is an attempt to resolve this,
+    % but it has not yet been satisfactorily fixed
+%     origwindowstyle = get(hfig, 'WindowStyle');
+    set(hfig, 'WindowStyle', 'normal');
+    
+    % 1 point is 0.3528 mm for future use
+
+    % get all the axes handles note this will also fetch legends and
+    % colorbars as well
+    hax = findall(hfig, 'type', 'axes');
+    % TODO: fix for modern matlab, colorbars and legends are no longer axes
+    hcbar = findall(hfig, 'type', 'colorbar');
+    hleg = findall(hfig, 'type', 'legend');
+    
+    % get the original axes units, so we can change and reset these again
+    % later
+    origaxunits = get(hax, 'Units');
+    
+    % change the axes units to cm
+    set(hax, 'Units', 'centimeters');
+    
+    pos = [];
+    ti = [];
+    
+    % get various position parameters of the axes
+    if numel(hax) > 1
+%         fsize = cell2mat(get(hax, 'FontSize'));
+        ti = cell2mat(get(hax,'TightInset'));
+        pos = [pos; cell2mat(get(hax, 'Position')) ];
+    else
+%         fsize = get(hax, 'FontSize');
+        ti = get(hax,'TightInset');
+        pos = [pos; get(hax, 'Position') ];
+    end
+    
+    if ~isempty (hcbar)
+        
+        set(hcbar, 'Units', 'centimeters');
+        
+        % colorbars do not have tightinset property
+        for cbind = 1:numel(hcbar)
+            %         fsize = cell2mat(get(hax, 'FontSize'));
+            [cbarpos, cbarti] = colorbarpos (hcbar);
+
+            pos = [pos; cbarpos];
+            ti = [ti; cbarti];
+        end
+    end
+    
+    if ~isempty (hleg)
+        
+        set(hleg, 'Units', 'centimeters');
+        
+        % legends do not have tightinset property
+        if numel(hleg) > 1
+            %         fsize = cell2mat(get(hax, 'FontSize'));
+            pos = [pos; cell2mat(get(hleg, 'Position')) ];
+        else
+            %         fsize = get(hax, 'FontSize');
+            pos = [pos; get(hleg, 'Position') ];
+        end
+        ti = [ti; repmat([0,0,0,0], numel(hleg), 1); ];
+    end
+    
+    % ensure very tiny border so outer box always appears
+    ti(ti < 0.1) = 0.15;
+    
+    % we will check if any 3d axes are zoomed, to do this we will check if
+    % they are not being viewed in any of the 2d directions
+    views2d = [0,90; 0,0; 90,0];
+    
+    for i = 1:numel(hax)
+        
+        set(hax(i), 'LooseInset', ti(i,:));
+%         set(hax(i), 'LooseInset', [0,0,0,0]);
+        
+        % get the current viewing angle of the axes
+        [az,el] = view(hax(i));
+        
+        % determine if the axes are zoomed
+        iszoomed = strcmp(get(hax(i), 'CameraViewAngleMode'), 'manual');
+        
+        % test if we are viewing in 2d mode or a 3d view
+        is2d = all(bsxfun(@eq, [az,el], views2d), 2);
+               
+        if iszoomed && ~any(is2d)
+           error('TIGHTFIG:haszoomed3d', 'Cannot make figures containing zoomed 3D axes tight.') 
+        end
+        
+    end
+    
+    % we will move all the axes down and to the left by the amount
+    % necessary to just show the bottom and leftmost axes and labels etc.
+    moveleft = min(pos(:,1) - ti(:,1));
+    
+    movedown = min(pos(:,2) - ti(:,2));
+    
+    % we will also alter the height and width of the figure to just
+    % encompass the topmost and rightmost axes and lables
+    figwidth = max(pos(:,1) + pos(:,3) + ti(:,3) - moveleft);
+    
+    figheight = max(pos(:,2) + pos(:,4) + ti(:,4) - movedown);
+    
+    % move all the axes
+    for i = 1:numel(hax)
+        
+        set(hax(i), 'Position', [pos(i,1:2) - [moveleft,movedown], pos(i,3:4)]);
+        
+    end
+    
+    for i = 1:numel(hcbar)
+        
+        set(hcbar(i), 'Position', [pos(i+numel(hax),1:2) - [moveleft,movedown], pos(i+numel(hax),3:4)]);
+        
+    end
+    
+    for i = 1:numel(hleg)
+        
+        set(hleg(i), 'Position', [pos(i+numel(hax)+numel(hcbar),1:2) - [moveleft,movedown], pos(i+numel(hax)+numel(hcbar),3:4)]);
+        
+    end
+    
+    origfigunits = get(hfig, 'Units');
+    
+    set(hfig, 'Units', 'centimeters');
+    
+    % change the size of the figure
+    figpos = get(hfig, 'Position');
+    
+    set(hfig, 'Position', [figpos(1), figpos(2), figwidth, figheight]);
+    
+    % change the size of the paper
+    set(hfig, 'PaperUnits','centimeters');
+    set(hfig, 'PaperSize', [figwidth, figheight]);
+    set(hfig, 'PaperPositionMode', 'manual');
+    set(hfig, 'PaperPosition',[0 0 figwidth figheight]);    
+    
+    % reset to original units for axes and figure 
+    if ~iscell(origaxunits)
+        origaxunits = {origaxunits};
+    end
+
+    for i = 1:numel(hax)
+        set(hax(i), 'Units', origaxunits{i});
+    end
+
+    set(hfig, 'Units', origfigunits);
+    
+%      set(hfig, 'WindowStyle', origwindowstyle);
+     
+end
+
+
+function [pos, ti] = colorbarpos (hcbar)
+
+    % 1 point is 0.3528 mm
+    
+    pos = hcbar.Position;
+    ti = [0,0,0,0];
+    
+    if ~isempty (strfind (hcbar.Location, 'outside'))
+
+        if strcmp (hcbar.AxisLocation, 'out')
+            
+            tlabels = hcbar.TickLabels;
+            
+            fsize = hcbar.FontSize;
+            
+            switch hcbar.Location
+                
+                case 'northoutside'
+                    
+                    % make exta space a little more than the font size/height
+                    ticklablespace_cm = 1.1 * (0.3528/10) * fsize;
+                    
+                    ti(4) = ti(4) + ticklablespace_cm;
+                    
+                case 'eastoutside'
+                    
+                    maxlabellen = max ( cellfun (@numel, tlabels, 'UniformOutput', true) );
+            
+                    % 0.62 factor is arbitrary and added because we don't
+                    % know the width of every character in the label, the
+                    % fsize refers to the height of the font
+                    ticklablespace_cm = (0.3528/10) * fsize * maxlabellen * 0.62;
+
+                    ti(3) = ti(3) + ticklablespace_cm;
+                    
+                case 'southoutside'
+                    
+                    % make exta space a little more than the font size/height
+                    ticklablespace_cm = 1.1 * (0.3528/10) * fsize;
+
+                    ti(2) = ti(2) + ticklablespace_cm;
+                    
+                case 'westoutside'
+                    
+                    maxlabellen = max ( cellfun (@numel, tlabels, 'UniformOutput', true) );
+            
+                    % 0.62 factor is arbitrary and added because we don't
+                    % know the width of every character in the label, the
+                    % fsize refers to the height of the font
+                    ticklablespace_cm = (0.3528/10) * fsize * maxlabellen * 0.62;
+
+                    ti(1) = ti(1) + ticklablespace_cm;
+                    
+            end
+            
+        end
+        
+    end
+
+end


### PR DESCRIPTION
@ahwillia Just fyi.

This is essentially a rewrite of `visualize_neuron_kfactor` to help me more quickly generate plots like in Fig. 6. Features include:

- Implemented your "soft clustering" neuron sorting scheme, with vertical lines indicate the boundaries in factor assignment (see screenshot below). The boundaries help me assess if there is any notable "mixing" between pairs of TCA factors.
- The time axis is plotted in real time by default. The alignment point (gate close) is indicated with a vertical dash line.
- I can click each trial vector subplot (rightmost column), to re-color the weights based on different metadata. Currently supports "start" / "end" / "correct" / "none", all using a color scheme similar to that in the paper. This was the main motivation for rewriting `visualize_neuron_ktensor`, as I found manually coloring the trial vector in Illustrator was way too time-consuming for looking at multiple datasets. In the future, I may update to have the function automatically select the initial coloring (right now it initializes on "none") based on a measure of separability of the two clouds of points.

<img width="699" alt="visualize_tca_factors" src="https://user-images.githubusercontent.com/2081503/37540456-37a8d56e-2914-11e8-9ee5-a5c3838b8f6d.png">
